### PR TITLE
response.players consistency

### DIFF
--- a/samp-query.js
+++ b/samp-query.js
@@ -37,7 +37,7 @@ var query = function (options, callback) {
             response.rules = rules
 
             if(response.online > 100) {
-                response.players = {}
+                response.players = []
 
                 return callback.apply(options, [ false, response ])
             }


### PR DESCRIPTION
`response.players` now returns an empty array instead of an empty object if more than 100 players are online. Since `response.players` is also an array if there are less than 100 (or none) players online, this should be the correct type.
