### PR TITLE
Updated samp-query.js to get server language

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ query(options, function (error, response) {
 	hostname: '• German Extreme Freeroam • Stunt/Derby/Race/DM/Free',
 	gamemode: 'Stunt Race Derby DM Fun',
 	mapname: 'San Andreas',
+	language: 'English',
 	passworded: false,
 	maxplayers: 500,
 	online: 12,

--- a/samp-query.js
+++ b/samp-query.js
@@ -26,6 +26,7 @@ var query = function (options, callback) {
         response.mapname = information.mapname
         response.passworded = information.passworded === 1
         response.maxplayers = information.maxplayers
+        response.language = information.language
         response.online = information.players
 
         request.call(self, options, 'r', function(error, rules) {
@@ -129,6 +130,8 @@ var request = function(options, opcode, callback) {
                     offset += 4
 
                     object.mapname = decode(message.slice(offset, offset += strlen))
+                    
+                    object.language = decode(message.slice(message.length - strlen))
 
                     return callback.apply(options, [ false, object ])
 


### PR DESCRIPTION
Return NULL when `language` called if not provided or supported